### PR TITLE
Move to a version of rest client that doesn't blow up.

### DIFF
--- a/lib/spectre_client/version.rb
+++ b/lib/spectre_client/version.rb
@@ -1,3 +1,3 @@
 module SpectreClient
-  VERSION = "0.1.87"
+  VERSION = "0.1.88"
 end

--- a/spectre_client.gemspec
+++ b/spectre_client.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_dependency "rest-client", "~> 1.8.0"
+  spec.add_dependency "rest-client", "=> 2.0.1"
 end


### PR DESCRIPTION
Due to a bug in rest-client: https://github.com/rest-client/rest-client/issues/569 we need version 2.0.1 or higher when running Ruby 2.4